### PR TITLE
Promotes # of Requests to a more visible place in bucket#show

### DIFF
--- a/app/models/bucket.rb
+++ b/app/models/bucket.rb
@@ -74,6 +74,10 @@ class Bucket
                      'body'    => e.message)
   end
 
+  def requests_count
+    requests.count
+  end
+
   def last_request
     requests.order(:created_at.desc).first
   end

--- a/app/views/buckets/_form.html.erb
+++ b/app/views/buckets/_form.html.erb
@@ -1,11 +1,21 @@
 <%= form_for @bucket, url: update_bucket_path(@bucket.token), method: :put do |f| %>
   <%= f.hidden_field :response_builder %>
   <script id="response-builder-container"  type='application/vns.putsreq-response_builder'><%== @bucket.response_builder %></script>
-  <h4>Bucket name
-  <small><em>You can change it anytime.</em></small>
-  </h4>
-  <div class="input-group putsreq-name bm30">
-    <%= f.text_field :name %>
+  <div class="row">
+    <div class="col-md-6">
+      <h4>Bucket name
+      <small><em>You can change it anytime.</em></small>
+      </h4>
+      <div class="input-group putsreq-name bm30">
+        <%= f.text_field :name %>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <h4>Requests
+      <small><em>The number of requests made to this bucket.</em></small>
+      </h4>
+      <h3><%= @bucket.requests_count %></h3>
+    </div>
   </div>
   <h4>Response Builder&nbsp;<a href="https://github.com/phstc/putsreq#response-builder" target="_blank"><span class="glyphicon glyphicon-info-sign"></span></a></h4>
   <div id="editor" name="editor" style="width: 100%; height: 250px"></div>

--- a/spec/models/bucket_spec.rb
+++ b/spec/models/bucket_spec.rb
@@ -164,6 +164,14 @@ describe Bucket do
     end
   end
 
+  describe '#requests_count' do
+    it 'returns the number of requests made to the bucket' do
+      expect {
+        subject.record_request(rack_request)
+      }.to change { subject.requests_count }.from(0).to(1)
+    end
+  end
+
   pending '#last_request'
   pending '#last_response'
 end


### PR DESCRIPTION
The number of requests made to the bucket is a useful information.

But it's only shown in the pagination, so I thought about promoting it to a more visible place.

wdyt?

![](http://f.cl.ly/items/2M0p1d130M1N3i120v2s/Screen%20Shot%202014-06-26%20at%2011.27.22%20AM.png) 
